### PR TITLE
Add reMarkable Move (chiappa) device support

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 pub enum DeviceModel {
     Remarkable2,
     RemarkablePaperPro,
+    RemarkableMove,
     Unknown,
 }
 
@@ -13,6 +14,9 @@ impl DeviceModel {
             if let Ok(hwrev) = std::fs::read_to_string("/etc/hwrevision") {
                 if hwrev.contains("ferrari 1.0") {
                     return DeviceModel::RemarkablePaperPro;
+                }
+                if hwrev.contains("chiappa 1.0") {
+                    return DeviceModel::RemarkableMove;
                 }
                 if hwrev.contains("reMarkable2 1.0") {
                     return DeviceModel::Remarkable2;
@@ -28,6 +32,7 @@ impl DeviceModel {
         match self {
             DeviceModel::Remarkable2 => "Remarkable2",
             DeviceModel::RemarkablePaperPro => "RemarkablePaperPro",
+            DeviceModel::RemarkableMove => "RemarkableMove",
             DeviceModel::Unknown => "Unknown",
         }
     }

--- a/src/pen.rs
+++ b/src/pen.rs
@@ -23,7 +23,7 @@ impl Pen {
 
         let pen_input_device = match device_model {
             DeviceModel::Remarkable2 => "/dev/input/event1",
-            DeviceModel::RemarkablePaperPro => "/dev/input/event2",
+            DeviceModel::RemarkablePaperPro | DeviceModel::RemarkableMove => "/dev/input/event2",
             DeviceModel::Unknown => "/dev/input/event1", // Default to RM2
         };
 
@@ -161,6 +161,7 @@ impl Pen {
         match self.device_model {
             DeviceModel::Remarkable2 => 15725,
             DeviceModel::RemarkablePaperPro => 11180,
+            DeviceModel::RemarkableMove => 6760,
             DeviceModel::Unknown => 15725, // Default to RM2
         }
     }
@@ -169,6 +170,7 @@ impl Pen {
         match self.device_model {
             DeviceModel::Remarkable2 => 20966,
             DeviceModel::RemarkablePaperPro => 15340,
+            DeviceModel::RemarkableMove => 11960,
             DeviceModel::Unknown => 20966, // Default to RM2
         }
     }
@@ -179,7 +181,7 @@ impl Pen {
         let y_normalized = y as f32 / VIRTUAL_HEIGHT as f32;
 
         match self.device_model {
-            DeviceModel::RemarkablePaperPro => {
+            DeviceModel::RemarkablePaperPro | DeviceModel::RemarkableMove => {
                 let x_input = (x_normalized * self.max_x_value() as f32) as i32;
                 let y_input = (y_normalized * self.max_y_value() as f32) as i32;
                 (x_input, y_input)

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -267,7 +267,8 @@ impl Screenshot {
     fn encode_png_move(&self, raw_data: &[u8]) -> Result<Vec<u8>> {
         // Move framebuffer is already in portrait orientation — no rotation needed
         // Move uses standard grayscale range — skip RM2's apply_curves which crushes to binary
-        let raw_u8: Vec<u8> = raw_data.chunks_exact(2).map(|chunk| u8::from_le_bytes([chunk[1]])).collect();
+        // Move stores grayscale in the LOW byte (chunk[0]), not high byte like RM2
+        let raw_u8: Vec<u8> = raw_data.chunks_exact(2).map(|chunk| u8::from_le_bytes([chunk[0]])).collect();
         let width = self.screen_width();
         let height = self.screen_height();
 

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -228,8 +228,12 @@ impl Screenshot {
                 // RMPP uses 32-bit RGBA format
                 self.encode_png_rmpp(raw_data)
             }
+            DeviceModel::RemarkableMove => {
+                // Move uses 16-bit grayscale, already in portrait orientation
+                self.encode_png_move(raw_data)
+            }
             _ => {
-                // RM2 and Move use 16-bit grayscale
+                // RM2 uses 16-bit grayscale, needs rotation
                 self.encode_png_rm2(raw_data)
             }
         }
@@ -256,6 +260,21 @@ impl Screenshot {
         let mut png_data = Vec::new();
         let encoder = image::codecs::png::PngEncoder::new(&mut png_data);
         encoder.write_image(final_image.as_raw(), final_image.width(), final_image.height(), image::ExtendedColorType::L8)?;
+
+        Ok(png_data)
+    }
+
+    fn encode_png_move(&self, raw_data: &[u8]) -> Result<Vec<u8>> {
+        // Move framebuffer is already in portrait orientation — no rotation needed
+        let raw_u8: Vec<u8> = raw_data.chunks_exact(2).map(|chunk| u8::from_le_bytes([chunk[1]])).collect();
+        let width = self.screen_width();
+        let height = self.screen_height();
+        let processed: Vec<u8> = raw_u8.iter().map(|&value| Self::apply_curves(value)).collect();
+
+        let img = GrayImage::from_raw(width, height, processed).ok_or_else(|| anyhow::anyhow!("Failed to create image from raw data"))?;
+        let mut png_data = Vec::new();
+        let encoder = image::codecs::png::PngEncoder::new(&mut png_data);
+        encoder.write_image(img.as_raw(), img.width(), img.height(), image::ExtendedColorType::L8)?;
 
         Ok(png_data)
     }

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -30,6 +30,7 @@ impl Screenshot {
         match self.device_model {
             DeviceModel::Remarkable2 => 1872,
             DeviceModel::RemarkablePaperPro => 1632,
+            DeviceModel::RemarkableMove => 960,
             DeviceModel::Unknown => 1872, // Default to RM2
         }
     }
@@ -38,6 +39,7 @@ impl Screenshot {
         match self.device_model {
             DeviceModel::Remarkable2 => 1404,
             DeviceModel::RemarkablePaperPro => 2154,
+            DeviceModel::RemarkableMove => 1696,
             DeviceModel::Unknown => 1404, // Default to RM2
         }
     }
@@ -46,6 +48,7 @@ impl Screenshot {
         match self.device_model {
             DeviceModel::Remarkable2 => 2,
             DeviceModel::RemarkablePaperPro => 4,
+            DeviceModel::RemarkableMove => 2,
             DeviceModel::Unknown => 2, // Default to RM2
         }
     }
@@ -88,8 +91,8 @@ impl Screenshot {
 
     fn find_framebuffer_address(&self, pid: &str) -> Result<u64> {
         match self.device_model {
-            DeviceModel::RemarkablePaperPro => {
-                // For RMPP (arm64), we need to use the approach from pointer_arm64.go
+            DeviceModel::RemarkablePaperPro | DeviceModel::RemarkableMove => {
+                // For RMPP/Move (arm64), we need to use the approach from pointer_arm64.go
                 let start_address = self.get_memory_range(pid)?;
                 let frame_pointer = self.calculate_frame_pointer(pid, start_address)?;
                 Ok(frame_pointer)
@@ -206,6 +209,7 @@ impl Screenshot {
                 )?;
             }
             _ => {
+                // RM2 and Move use grayscale
                 encoder.write_image(
                     resized_img.as_luma8().unwrap().as_raw(),
                     VIRTUAL_WIDTH,
@@ -225,7 +229,7 @@ impl Screenshot {
                 self.encode_png_rmpp(raw_data)
             }
             _ => {
-                // RM2 uses 16-bit grayscale
+                // RM2 and Move use 16-bit grayscale
                 self.encode_png_rm2(raw_data)
             }
         }

--- a/src/screenshot.rs
+++ b/src/screenshot.rs
@@ -266,12 +266,12 @@ impl Screenshot {
 
     fn encode_png_move(&self, raw_data: &[u8]) -> Result<Vec<u8>> {
         // Move framebuffer is already in portrait orientation — no rotation needed
+        // Move uses standard grayscale range — skip RM2's apply_curves which crushes to binary
         let raw_u8: Vec<u8> = raw_data.chunks_exact(2).map(|chunk| u8::from_le_bytes([chunk[1]])).collect();
         let width = self.screen_width();
         let height = self.screen_height();
-        let processed: Vec<u8> = raw_u8.iter().map(|&value| Self::apply_curves(value)).collect();
 
-        let img = GrayImage::from_raw(width, height, processed).ok_or_else(|| anyhow::anyhow!("Failed to create image from raw data"))?;
+        let img = GrayImage::from_raw(width, height, raw_u8).ok_or_else(|| anyhow::anyhow!("Failed to create image from raw data"))?;
         let mut png_data = Vec::new();
         let encoder = image::codecs::png::PngEncoder::new(&mut png_data);
         encoder.write_image(img.as_raw(), img.width(), img.height(), image::ExtendedColorType::L8)?;

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -176,7 +176,7 @@ impl Touch {
         match self.device_model {
             DeviceModel::Remarkable2 => 1404,
             DeviceModel::RemarkablePaperPro => 2065,
-            DeviceModel::RemarkableMove => 2065, // Same Elan touch controller
+            DeviceModel::RemarkableMove => 1248,
             DeviceModel::Unknown => 1404, // Default to RM2
         }
     }
@@ -185,7 +185,7 @@ impl Touch {
         match self.device_model {
             DeviceModel::Remarkable2 => 1872,
             DeviceModel::RemarkablePaperPro => 2833,
-            DeviceModel::RemarkableMove => 2833, // Same Elan touch controller
+            DeviceModel::RemarkableMove => 2208,
             DeviceModel::Unknown => 1872, // Default to RM2
         }
     }

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -59,7 +59,7 @@ impl Touch {
 
         let device_path = match device_model {
             DeviceModel::Remarkable2 => "/dev/input/event2",
-            DeviceModel::RemarkablePaperPro => "/dev/input/event3",
+            DeviceModel::RemarkablePaperPro | DeviceModel::RemarkableMove => "/dev/input/event3",
             DeviceModel::Unknown => "/dev/input/event2", // Default to RM2
         };
 
@@ -176,6 +176,7 @@ impl Touch {
         match self.device_model {
             DeviceModel::Remarkable2 => 1404,
             DeviceModel::RemarkablePaperPro => 2065,
+            DeviceModel::RemarkableMove => 2065, // Same Elan touch controller
             DeviceModel::Unknown => 1404, // Default to RM2
         }
     }
@@ -184,6 +185,7 @@ impl Touch {
         match self.device_model {
             DeviceModel::Remarkable2 => 1872,
             DeviceModel::RemarkablePaperPro => 2833,
+            DeviceModel::RemarkableMove => 2833, // Same Elan touch controller
             DeviceModel::Unknown => 1872, // Default to RM2
         }
     }
@@ -194,7 +196,7 @@ impl Touch {
         let y_normalized = y as f32 / VIRTUAL_HEIGHT as f32;
 
         match self.device_model {
-            DeviceModel::RemarkablePaperPro => {
+            DeviceModel::RemarkablePaperPro | DeviceModel::RemarkableMove => {
                 let x_input = (x_normalized * self.screen_width() as f32) as i32;
                 let y_input = (y_normalized * self.screen_height() as f32) as i32;
                 (x_input, y_input)
@@ -214,7 +216,7 @@ impl Touch {
         let y_normalized = y as f32 / self.screen_height() as f32;
 
         match self.device_model {
-            DeviceModel::RemarkablePaperPro => {
+            DeviceModel::RemarkablePaperPro | DeviceModel::RemarkableMove => {
                 let x_input = (x_normalized * VIRTUAL_WIDTH as f32) as i32;
                 let y_input = (y_normalized * VIRTUAL_HEIGHT as f32) as i32;
                 (x_input, y_input)

--- a/src/util.rs
+++ b/src/util.rs
@@ -91,6 +91,39 @@ pub fn setup_uinput() -> Result<()> {
         return Ok(());
     }
 
+    if device_model == DeviceModel::RemarkableMove {
+        // Check if uinput module is loaded by looking at the lsmod output
+        let output = std::process::Command::new("lsmod").output().expect("Failed to execute lsmod");
+        let output_str = std::str::from_utf8(&output.stdout).unwrap();
+        if output_str.contains("uinput") {
+            debug!("uinput module already loaded");
+            return Ok(());
+        }
+        // Try loading system module via modprobe
+        info!("Move: attempting to load system uinput module");
+        let output = std::process::Command::new("modprobe").arg("uinput").output();
+        if let Ok(result) = output {
+            if result.status.success() {
+                info!("System uinput module loaded via modprobe");
+                return Ok(());
+            }
+        }
+        // Fall back to finding and loading the module directly
+        let find_output = std::process::Command::new("find")
+            .args(&["/usr/lib/modules", "-name", "uinput.ko"])
+            .output();
+        if let Ok(result) = find_output {
+            let module_path = std::str::from_utf8(&result.stdout).unwrap().trim().to_string();
+            if !module_path.is_empty() {
+                info!("Loading uinput from: {}", module_path);
+                let _ = std::process::Command::new("insmod").arg(&module_path).output();
+                return Ok(());
+            }
+        }
+        info!("Could not load uinput module for Move - keyboard input may not work");
+        return Ok(());
+    }
+
     // Check if uinput module is loaded by looking at the lsmod output
     let output = std::process::Command::new("lsmod").output().expect("Failed to execute lsmod");
     let output_str = std::str::from_utf8(&output.stdout).unwrap();


### PR DESCRIPTION
## Summary

Adds reMarkable Move ("chiappa") device support to Ghostwriter. The Move is reMarkable's 7.3" tablet using the i.MX93 SoC — same architecture as Paper Pro (aarch64) but with different display hardware.

**Key discoveries:**
- **Framebuffer: 960x1696, 2bpp, 16-bit little-endian grayscale** (low byte carries the grayscale value)
- Physical display is 954 pixels wide, but framebuffer stride is 960 (padded to 32-pixel alignment)
- Uses the Paper Pro's DRI card0 pointer-scanning approach for framebuffer location
- Framebuffer is already in portrait orientation (no rotation needed, unlike RM2)
- Touch digitizer range is 1248x2208 (different from Paper Pro's 2065x2833)
- Pen digitizer range is 6760x11960
- System uinput.ko module works — no bundled module needed

**Files changed (5 files, ~60 lines):**
-  — Add  variant, detect "chiappa 1.0" in 
-  — Move-specific encoder: 960x1696, low byte extraction, no rotation, no RM2 tone curve
-  — Load system uinput module via modprobe/insmod instead of bundled modules
-  — Move pen input path and coordinate ranges (event2, 6760x11960)
-  — Move touch input path and coordinate ranges (event3, 1248x2208)

## Test plan

- [x] Device detection: "RemarkableMove" logged on boot
- [x] Screenshot capture: clean grayscale PNG with readable text and icons
- [x] API round-trip: screenshot sent to Claude Sonnet, response received
- [x] SVG drawing: response rendered on screen
- [x] Touch trigger: lower-left corner tap triggers correctly
- [x] Tested on firmware 3.26.0.68 (chiappa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>